### PR TITLE
Split long RUN instructions into multiple lines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,15 @@ ENV GNUPG_VERSION=2.2.40-1.1
 
 RUN apt-get update -y && \
   # Install necessary dependencies
-  apt-get install -y --no-install-recommends curl=${CURL_VERSION} gnupg=${GNUPG_VERSION} && \
+  apt-get install -y --no-install-recommends \
+    curl=${CURL_VERSION} \
+    gnupg=${GNUPG_VERSION} && \
   # Add NodeJS PPA
-  curl --proto "=https" -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  curl --proto "=https" -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
   NODE_MAJOR=22 && \
-  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
+    | tee /etc/apt/sources.list.d/nodesource.list
 
 
 # Final image


### PR DESCRIPTION
Split long RUN instructions into mulitple lines to make it easier to read and understand.

Fixes https://rules.sonarsource.com/docker/RSPEC-7020/