### PR TITLE
Disable default `latest` and `unstable` tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
     uses: swissgrc/.github/.github/workflows/publish-image.yml@main
     with:
       image-name: swissgrc/azure-pipelines-node
-      default-latest-tag: true
+      default-latest-tag: false
       additional-latest-tag-name: latest-22-net8
-      default-unstable-tag: true
+      default-unstable-tag: false
       additional-unstable-tag-name: unstable-22-net8
       release-tag-suffix: net8
     secrets:


### PR DESCRIPTION
Disables default `latest` and `unstable` tags, as they will be published by https://github.com/swissgrc/docker-azure-pipelines-node22-net9